### PR TITLE
Balance V3: Small damage Tweaks

### DIFF
--- a/zscript/biorifle.zsc
+++ b/zscript/biorifle.zsc
@@ -409,7 +409,7 @@ Class BioGel : Actor
 		s.args[3] = int(s.args[3]*Scale.x);
 		invoker.deadtimer = -2;
 		if ( invoker.atline ) invoker.atline.RemoteActivate(target,invoker.atside,SPAC_Impact,pos);
-		A_Explode(int(Random[GES](10,15)*max(1,(Scale.x-1)**2)),Min(150,int(Scale.x*25)));
+		A_Explode(int(Random[GES](20,22)*max(1,(Scale.x-1)**2)),Min(150,int(Scale.x*25)));
 		A_PlaySound("ges/explode",CHAN_VOICE);
 		int numpt = Min(300,int(Scale.x*30))+Random[GES](-10,10);
 		for ( int i=0; i<numpt; i++ )

--- a/zscript/flakcannon.zsc
+++ b/zscript/flakcannon.zsc
@@ -140,7 +140,7 @@ Class FlakChunk : Actor
 		Radius 2;
 		Height 2;
 		Speed 50;
-		DamageFunction int(Random[Flak](15,20)*max(0.1,1.0-lifetime*4.1));
+		DamageFunction int(Random[Flak](25,27)*max(0.1,1.0-lifetime*16));
 		DamageType 'Shredded';
 		BounceType "Doom";
 		BounceFactor 0.8;
@@ -359,7 +359,7 @@ Class FlakSlug : Actor
 	{
 		Obituary "%o was ripped to shreds by %k's Flak Cannon.";
 		DamageType 'FlakDeath';
-		DamageFunction Random[Flak](100,110);
+		DamageFunction Random[Flak](20,30);
 		Radius 2;
 		Height 2;
 		Speed 40;
@@ -387,7 +387,7 @@ Class FlakSlug : Actor
 		A_SprayDecal("RocketBlast",150);
 		A_NoGravity();
 		A_SetScale(1.2);
-		A_Explode(Random[Flak](70,80),80);
+		A_Explode(Random[Flak](30,40),80);
 		A_QuakeEx(4,4,4,8,0,200,"",QF_RELATIVE|QF_SCALEDOWN,rollIntensity:0.2);
 		A_PlaySound("flak/explode",CHAN_VOICE);
 		A_AlertMonsters();

--- a/zscript/shockrifle.zsc
+++ b/zscript/shockrifle.zsc
@@ -337,7 +337,7 @@ Class ShockBeam : Actor
 				if ( target ) target.TakeInventory('ShockAmmo',2);
 				let b = t.Results.HitActor.target;
 				b.ExplodeMissile(null,self);
-				b.A_Explode(Random[ASMD](150,160),300);
+				b.A_Explode(Random[ASMD](180,200),300);
 				b.A_QuakeEx(6,6,6,60,0,1200,"",QF_RELATIVE|QF_SCALEDOWN,rollIntensity:0.2);
 				b.A_SprayDecal("BigShockMark1",100);
 				b.A_SprayDecal("BigShockMark2",100);


### PR DESCRIPTION
-Tweaked Biorifle damage to deal 30~ Min, 550~ Max
-Rebalanced Flak Cannon DPS to favour its primary fire.
-Made the Flak Cannon Primary's damage falloff harsher.
-Increased Shock Combo damage to 190~

Notes: After these changes I feel happy with how damage is balanced across the board. Next up are changes regarding weapon progression/drops along the game.
In any case... Some notes about your recent changes:

-The Chainsaw's lameness is gone! Its fun to use and found its own niche against crowds of pinkies.
-The Enforcer's reduced damage/firing speed made the Minigun relevant again.
-Armor/Shield is still broken. (Armor doesn't add correctly after the shield)